### PR TITLE
Include algorithm library. Allows Linux build.

### DIFF
--- a/VibRipper/Repacker.cpp
+++ b/VibRipper/Repacker.cpp
@@ -7,6 +7,7 @@
 /* GitHub: resistiv                                 */
 /* ------------------------------------------------ */
 
+#include <algorithm>
 #include "Repacker.h"
 #include "VibRipper.h"
 

--- a/VibRipper/Unpacker.cpp
+++ b/VibRipper/Unpacker.cpp
@@ -7,6 +7,7 @@
 /* GitHub: resistiv                                 */
 /* ------------------------------------------------ */
 
+#include <algorithm>
 #include "Unpacker.h"
 #include "VibRipper.h"
 

--- a/VibRipper/VibRipper.cpp
+++ b/VibRipper/VibRipper.cpp
@@ -8,6 +8,7 @@
 /* ------------------------------------------------ */
 
 #include <iostream>
+#include <algorithm>
 #include "Repacker.h"
 #include "Unpacker.h"
 #include "VibRipper.h"

--- a/VibRipper/VibRipper.cpp
+++ b/VibRipper/VibRipper.cpp
@@ -8,7 +8,6 @@
 /* ------------------------------------------------ */
 
 #include <iostream>
-#include <algorithm>
 #include "Repacker.h"
 #include "Unpacker.h"
 #include "VibRipper.h"


### PR DESCRIPTION
The `std::replace` command would throw an error when compiling on Linux. By adding `#include <algorithm>`, this issue is fixed. With this change, the program now runs perfectly on Linux.

Linux build:
[VibRipper.zip](https://github.com/user-attachments/files/16260887/VibRipper.zip)
